### PR TITLE
[FIX] 아이템 구매 취소 시 인벤토리 리스트 유지

### DIFF
--- a/src/app/activity/list/page.tsx
+++ b/src/app/activity/list/page.tsx
@@ -53,7 +53,6 @@ const ActivitySelectClientPage = () => {
 
       {/* 탭 내용 */}
       <div className="flex-1 overflow-y-hidden">
-        <PreventIOSPullToRefresh />
         {activeTab === "select" ? <ActivityList /> : <StatusList />}
       </div>
     </div>

--- a/src/entities/room/ui/InventoryList.tsx
+++ b/src/entities/room/ui/InventoryList.tsx
@@ -196,6 +196,8 @@ const InventoryListComponent = () => {
             </div>
           </motion.div>
         )}{" "}
+      </AnimatePresence>
+      <AnimatePresence mode="wait">
         {modal && modalType === "buy" && (
           <CommonModal
             isOpen={modal}


### PR DESCRIPTION
## 🔍 관련 이슈
-

## ✅ 변경 내용 요약
- 아이템 구매 취소 시 인벤토리 리스트 유지

## 📎 기타 참고 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * iOS에서 탭 콘텐츠 내에서 불필요하게 적용되던 화면 당김 방지 기능이 제거되었습니다.

* **스타일**
  * 인벤토리 리스트와 모달 애니메이션이 서로 독립적으로 동작하도록 개선되어, 전환 효과가 더욱 자연스러워졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->