### PR TITLE
[FIX] 마이페이지 커플 이미지 클릭이벤트 영역 수정

### DIFF
--- a/src/app/activity/list/page.tsx
+++ b/src/app/activity/list/page.tsx
@@ -53,6 +53,7 @@ const ActivitySelectClientPage = () => {
 
       {/* 탭 내용 */}
       <div className="flex-1 overflow-y-hidden">
+        <PreventIOSPullToRefresh/>
         {activeTab === "select" ? <ActivityList /> : <StatusList />}
       </div>
     </div>

--- a/src/entities/user/ui/CustomProfile.tsx
+++ b/src/entities/user/ui/CustomProfile.tsx
@@ -50,8 +50,9 @@ const CustomProfile = () => {
           src={data?.data.profileImageUrl || "/image/couple/defaultProfile.png"}
           fill
           alt="커플 프로필 이미지"
-          className="object-cover"
+          className="object-cover cursor-pointer"
           draggable={false}
+          onClick={openFileDialog}
         />
 
         <input

--- a/src/features/certification/ui/ActivityList.tsx
+++ b/src/features/certification/ui/ActivityList.tsx
@@ -145,7 +145,7 @@ const ActivityList = () => {
   };
 
   return (
-    <div className="scrollable-area bg-white h-full overflow-y-scroll no-scrollbar relative">
+    <div className="scrollable-area bg-white overflow-y-scroll no-scrollbar relative">
       {isOpen && <Toast message={message} position="top" />}
       {(isPending || loading) && <LogoLoading />}
       {isModalOpen && (

--- a/src/features/certification/ui/StatusList.tsx
+++ b/src/features/certification/ui/StatusList.tsx
@@ -40,7 +40,6 @@ const StatusList = () => {
 
   return (
     <div className="bg-[#F4F5F7] flex flex-col gap-2.5 py-8 px-5 no-scrollbar overflow-y-hidden h-full">
-      <PreventIOSPullToRefresh />
       {!isPending && items.length === 0 ? (
         <div className="text-center text-lg font-semibold text-[#777777] flex items-center justify-center h-full pb-48">
           아직 모인 활동이 없어요! <br />

--- a/src/widgets/home/BottomButtons.tsx
+++ b/src/widgets/home/BottomButtons.tsx
@@ -42,7 +42,7 @@ const BottomButtons = ({ type = null }: BottomButtonsProps) => {
         <div
           className={`flex ${
             type === "description" ? "w-[48%]" : "w-full"
-          }  justify-center gap-4 mb-9 `}
+          }  justify-center gap-4 pb-9 `}
         >
           <button
             type="button"

--- a/src/widgets/home/BottomNavigationBar.tsx
+++ b/src/widgets/home/BottomNavigationBar.tsx
@@ -14,14 +14,14 @@ const BottomNavigationBar = () => {
     <div className="flex flex-col items-center justify-center w-full h-full">
       {mode === "home" && (
         <div className="flex w-full items-center justify-center relative">
-          <Image
-            onClick={() => window.location.reload()}
-            className="absolute left-1/2  bottom-4 md:bottom-8 z-2  -translate-x-1/2 cursor-pointer"
-            src="/icon/home/reloadIcon.svg"
-            alt="새로고침 아이콘"
-            width={40}
-            height={40}
-          />
+          {/*<Image*/}
+          {/*  onClick={() => window.location.reload()}*/}
+          {/*  className="absolute left-1/2  bottom-4 md:bottom-8 z-2  -translate-x-1/2 cursor-pointer"*/}
+          {/*  src="/icon/home/reloadIcon.svg"*/}
+          {/*  alt="새로고침 아이콘"*/}
+          {/*  width={40}*/}
+          {/*  height={40}*/}
+          {/*/>*/}
           <div className="absolute right-0 bottom-4 md:bottom-8 z-2">
             <NameBoard />
           </div>


### PR DESCRIPTION
## ✅ 변경 내용 요약
- 마이페이지 커플 이미지 클릭이벤트 영역 변경
- 홈화면 새로고침 버튼 삭제
- 홈화면 아랫부분 버튼 2개 margin -> padding으로 변경

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * iOS에서 풀투리프레시 방지 기능이 탭 콘텐츠 영역에 추가되었습니다.
  * 프로필 이미지를 클릭하여 프로필 사진을 업로드할 수 있습니다.

* **스타일**
  * 버튼 하단 여백이 margin에서 padding으로 변경되었습니다.
  * 활동 목록 컨테이너의 전체 높이 강제 적용(h-full) 스타일이 제거되었습니다.

* **버그 수정**
  * 상태 목록에서 iOS 풀투리프레시 방지 기능이 제거되었습니다.
  * 홈 화면 하단 네비게이션바의 새로고침 아이콘이 비활성화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->